### PR TITLE
updating type for url

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,7 @@ client := twilio.NewClient(sid, token, nil)
 msg, err := client.Messages.SendMessage("+14105551234", "+14105556789", "Sent via go :) ✓", nil)
 
 // Start a phone call
-call, err := client.Calls.MakeCall("+14105551234", "+14105556789",
-        "https://kev.inburke.com/zombo/zombocom.mp3")
+call, err := client.Calls.MakeCall("+14105551234", "+14105556789", &url.URL{Scheme: "https", Host: "kev.inburke.com", Path: "zombo/zombocom.mp3"})
 
 // Buy a number
 number, err := client.IncomingNumbers.BuyNumber("+14105551234")


### PR DESCRIPTION
In the README the url for making a call is a string, whereas in the code is an `url.URL`