### PR TITLE
Set proper JSON serialization of the scope

### DIFF
--- a/twilioclient/capabilities.go
+++ b/twilioclient/capabilities.go
@@ -58,7 +58,7 @@ func (c *Capability) AllowEventStream(filters map[string]string) {
 
 type customClaim struct {
 	*jwt.StandardClaims
-	Scope string
+	Scope string `json:"scope"`
 }
 
 // Generate the twilio capability token. Deliver this token to your


### PR DESCRIPTION
Currently the `scope` claim is being serialized as `Scope` which causes the Twillio's JavaScript SDK library to fail on line:

```javascript
5946: var scopes = (jwt.scope.length === 0 ? [] : jwt.scope.split(' '));
```