### PR TITLE
Fixing github.com/saintpete/twilio-go/http.go:110:3: unknown field 'S…

### DIFF
--- a/http.go
+++ b/http.go
@@ -107,7 +107,7 @@ func parseTwilioError(resp *http.Response) error {
 		Title:      rerr.Message,
 		Type:       rerr.MoreInfo,
 		ID:         strconv.FormatInt(int64(rerr.Code), 10),
-		StatusCode: resp.StatusCode,
+		Status: resp.StatusCode,
 	}
 }
 


### PR DESCRIPTION
Addresses the issue in github.com/saintpete/twilio-go/http.go:110:3: unknown field 'StatusCode' in struct literal of type rest.Error
